### PR TITLE
fix: change NuGet package name

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -34,8 +34,8 @@ const project = new CdklabsConstructLibrary({
     module: 'aws_cdk.aws_lambda_dotnet',
   },
   publishToNuget: {
-    dotNetNamespace: 'Amazon.CDK.AwsLambdaDotnet',
-    packageId: 'Amazon.CDK.AwsLambdaDotnet',
+    dotNetNamespace: 'Amazon.CDK.AWS.Lambda.DotNet',
+    packageId: 'Amazon.CDK.AWS.Lambda.DotNet',
   },
   autoApproveUpgrades: true,
   prettier: true,

--- a/package.json
+++ b/package.json
@@ -142,8 +142,8 @@
         "module": "aws_cdk.aws_lambda_dotnet"
       },
       "dotnet": {
-        "namespace": "Amazon.CDK.AwsLambdaDotnet",
-        "packageId": "Amazon.CDK.AwsLambdaDotnet"
+        "namespace": "Amazon.CDK.AWS.Lambda.DotNet",
+        "packageId": "Amazon.CDK.AWS.Lambda.DotNet"
       }
     },
     "tsc": {


### PR DESCRIPTION
Change NuGet package to `Amazon.CDK.AWS.Lambda.DotNet` to stay inline with existing package names.