### PR TITLE
fix: Skip invocation of hooks and unzip / delete commands if no hooks are registered

### DIFF
--- a/src/private/bundling.ts
+++ b/src/private/bundling.ts
@@ -42,6 +42,7 @@ export class Bundling implements cdk.BundlingOptions {
         : cdk.AssetHashType.SOURCE,
       exclude: ['**/bin/', '**/obj/'],
       bundling: {
+        outputType: cdk.BundlingOutput.AUTO_DISCOVER,
         image: bundling.image,
         command: bundling.command,
         environment: bundling.environment,
@@ -164,6 +165,12 @@ export class Bundling implements cdk.BundlingOptions {
     ]
       .filter((c) => !!c)
       .join(' ');
+
+    // Skip invocation of hooks and unzip / delete commands if no hooks are registered
+    if (!this.props.commandHooks) {
+      return dotnetPackageCommand;
+    }
+
     const unzipCommand: string =
       osPlatform === 'win32'
         ? [
@@ -182,11 +189,11 @@ export class Bundling implements cdk.BundlingOptions {
         : ['rm', packageFile].filter((c) => !!c).join(' ');
 
     return chain([
-      ...(this.props.commandHooks?.beforeBundling(inputDir, outputDir) ?? []),
+      ...(this.props.commandHooks.beforeBundling(inputDir, outputDir) ?? []),
       dotnetPackageCommand,
       unzipCommand,
       deleteCommand,
-      ...(this.props.commandHooks?.afterBundling(inputDir, outputDir) ?? []),
+      ...(this.props.commandHooks.afterBundling(inputDir, outputDir) ?? []),
     ]);
   }
 }


### PR DESCRIPTION
Thanks for creating this construct - it makes working with .NET Lambda functions in CDK a much better experience!

Out of curiosity I have been reading through the code base to learn more about how this construct has been implemented, and I noticed a minor optimization that can be done.

The construct was already (implicitly) using `AUTO_DISCOVER` as bundling output type, which according to the docs means:

> If the bundling output directory contains a single archive file (zip or jar) it will be used as the bundle output as-is. Otherwise, all the files in the bundling output directory will be zipped.

This also means that if no hooks are registered, then there is a such no need to go through the work of unzipping the produced `package.zip` file, just for the CDK to zip it again.

This PR introduces a simple check, to see if hooks are registered, and if not, the produced command is simply just the `dotnetPackageCommand` which spits out a `package.zip`, which, due to the use of `AUTO_DISCOVER` as bundling output type, is then picked up and use as code asset by the CDK.

On top of this, while the bundling output type in CDK does default to `AUTO_DISCOVER`, I have now configured it in code, just to make it explicit that the this "auto mode" is in fact used as part of the construct's logic.